### PR TITLE
Add vulnerability tests

### DIFF
--- a/moreTest.py
+++ b/moreTest.py
@@ -1,7 +1,8 @@
 import unittest
+import tempfile
 from hotel import Hotel
 from stanze import Singola, Doppia
-from classi import Data
+from classi import Data, Prenotazione
 
 class TestHotelExtra(unittest.TestCase):
     def test_data_from_string(self):
@@ -19,6 +20,45 @@ class TestHotelExtra(unittest.TestCase):
         h.rimuovi_stanza(100)
         self.assertNotIn(100, h.stanze)
         self.assertEqual(len(h.prenotazioni), 0)
+
+class TestHotelVulnerabilities(unittest.TestCase):
+    """Test che verificano la corrispondenza fra i commenti e l'implementazione."""
+
+    def test_stanza_prezzo_base_validation(self):
+        """Il commento indica che il prezzo deve essere > 1."""
+        with self.assertRaises(ValueError):
+            Singola(200, 0.5)
+
+    def test_prenotazione_cross_year_not_allowed(self):
+        """Le specifiche vietano prenotazioni a cavallo di due anni."""
+        h = Hotel()
+        h.aggiungi_stanza(Singola(101, 50.0))
+        with self.assertRaises(ValueError):
+            h.prenota(101, Data(31,12), Data(1,1), "Test", 1)
+
+    def test_nome_cliente_troppo_corto(self):
+        """Verifica che venga sollevata eccezione per nomi troppo brevi."""
+        with self.assertRaises(ValueError):
+            Prenotazione(1,101, Data(1,1), Data(2,1), "Al", 1)
+
+    def test_numero_persone_deve_essere_positivo(self):
+        """Lo stato richiede numero_persone positivo (>0)."""
+        with self.assertRaises(ValueError):
+            Prenotazione(2,101, Data(1,1), Data(2,1), "Mario", 0)
+
+    def test_data_bool_non_valida(self):
+        """I parametri giorno e mese dovrebbero essere interi e non booleani."""
+        with self.assertRaises(TypeError):
+            Data(True, 1)
+
+    def test_carica_formato_non_valido(self):
+        """Il metodo carica dovrebbe sollevare ValueError su formato errato."""
+        h = Hotel()
+        with tempfile.NamedTemporaryFile("w", delete=False) as tf:
+            tf.write("Qualcosa\n")
+            nome = tf.name
+        with self.assertRaises(ValueError):
+            h.carica(nome)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `moreTest.py` with tests verifying various assumptions from code comments

## Testing
- `python -m unittest moreTest.py` *(fails: 3 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1616be483269ab76f30a49d531e